### PR TITLE
feat: use PostgreSQL as db

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	runtimeOnly("com.h2database:h2")
+	runtimeOnly("org.postgresql:postgresql")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	runtimeOnly("org.postgresql:postgresql")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
+	developmentOnly("org.springframework.boot:spring-boot-docker-compose")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/docker/postgresql.yml
+++ b/src/main/docker/postgresql.yml
@@ -1,0 +1,15 @@
+name: bonacompra
+services:
+  postgresql:
+    image: postgres:17.5
+    environment:
+      # 👇 Default value, but here for explicitness. Also creates a db with the same name.
+      - POSTGRES_USER=postgres
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U $${POSTGRES_USER}']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "127.0.0.1:5432:5432"

--- a/src/main/docker/services.yml
+++ b/src/main/docker/services.yml
@@ -1,0 +1,6 @@
+name: bonacompra
+services:
+  postgresql:
+    extends:
+      file: ./postgresql.yml
+      service: postgresql

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,5 @@ spring.application.name=bonacompra
 spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
 spring.datasource.username=postgres
 spring.jpa.hibernate.ddl-auto=create-drop
+# OpenInView: keep a session for every request. Disabled for perf.
+spring.jpa.open-in-view=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=bonacompra
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.username=postgres
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,7 @@ spring.datasource.username=postgres
 spring.jpa.hibernate.ddl-auto=create-drop
 # OpenInView: keep a session for every request. Disabled for perf.
 spring.jpa.open-in-view=false
+# Below only for dev
+spring.docker.compose.enabled=true
+spring.docker.compose.lifecycle-management=start_only
+spring.docker.compose.file=src/main/docker/services.yml


### PR DESCRIPTION
Adds PostgreSQL driver, Docker Compose to launch it locally and configures the data source accordingly

TODO: 
 - Use Spring Boot docker compose to wake the instance automagically. Only in dev.
 - Use something other than `create-drop`
